### PR TITLE
feat: Add dynamic IP detection for web GUI network accessibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1145,9 +1145,6 @@ async function startWebGUI() {
   // Start servers
   const guiServer = guiApp.listen(guiPort, '0.0.0.0', () => {
     console.log(chalk.green(`🎨 Web Dashboard: http://${primaryIP}:${guiPort}`));
-    if (primaryIP !== 'localhost') {
-      console.log(chalk.gray(`   Local access: http://localhost:${guiPort}`));
-    }
     if (config.dashboardPassword) {
       console.log(chalk.gray('   Use any username with your configured password to access'));
     }
@@ -1156,9 +1153,13 @@ async function startWebGUI() {
   const metricsServer = metricsApp.listen(metricsPort, '0.0.0.0', () => {
     console.log(chalk.green(`📊 Metrics API: http://${primaryIP}:${metricsPort}/metrics`));
     console.log(chalk.green(`❤️  Health Check: http://${primaryIP}:${metricsPort}/health`));
+    
+    // Show local URLs in a separate section if not localhost
     if (primaryIP !== 'localhost') {
-      console.log(chalk.gray(`   Local metrics: http://localhost:${metricsPort}/metrics`));
-      console.log(chalk.gray(`   Local health: http://localhost:${metricsPort}/health`));
+      console.log(chalk.blue('\n📍 Local Access:'));
+      console.log(chalk.gray(`   Dashboard: http://localhost:${guiPort}`));
+      console.log(chalk.gray(`   Metrics: http://localhost:${metricsPort}/metrics`));
+      console.log(chalk.gray(`   Health: http://localhost:${metricsPort}/health`));
     }
   });
   


### PR DESCRIPTION
## Summary
Adds automatic detection of the primary local IP address to make the web GUI accessible from other devices on the network, whilst maintaining localhost fallback functionality.

## Changes
- **New function `getPrimaryLocalIP()`**: Intelligently detects the primary network interface IP address
  - Prioritises physical interfaces (Ethernet, WiFi) over virtual ones (Docker, VMware, VirtualBox)
  - Filters out loopback and virtual container networks
  - Prefers private network IP ranges (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
  - Cross-platform support for Windows, macOS, and Linux

- **Enhanced server binding**: Web servers now bind to `0.0.0.0` instead of localhost only
- **Dynamic URL display**: Dashboard and metrics URLs now show the detected primary IP
- **Improved logging**: Shows both network-accessible URLs and localhost URLs for convenience
- **Updated dashboard**: API endpoints in the web interface now display the correct network IP

## Benefits
- **Network accessibility**: Other devices on the same network can now access the web dashboard
- **Intelligent interface selection**: Automatically chooses the best available network interface
- **Fallback safety**: Maintains localhost functionality as a fallback option
- **Better UX**: Users can easily access the dashboard from mobile devices or other computers

## Testing
- Tested across different network configurations
- Handles cases with multiple network interfaces (physical + virtual)
- Graceful fallback to localhost when primary IP detection fails
- Works with Docker, VMware, and other virtualisation platforms present

## Example
```bash
🌐 Starting synchronizer Web GUI
Setting up web dashboard and metrics endpoints...

⚠️  Dashboard is unprotected - consider setting a password
🌐 Detected primary IP: 192.168.1.212 (eth0)
🔍 Finding available ports...

🔄 Auto-refresh dashboard every 5 seconds
Press Ctrl+C to stop the web servers

🎨 Web Dashboard: http://192.168.1.212:3000
📊 Metrics API: http://192.168.1.212:3001/metrics
❤️  Health Check: http://192.168.1.212:3001/health

📍 Local Access:
   Dashboard: http://localhost:3000
   Metrics: http://localhost:3001/metrics
   Health: http://localhost:3001/health
```

## Breaking Changes
None - maintains full backward compatibility with existing localhost functionality.